### PR TITLE
Only inhibit weapon select when using number key binds

### DIFF
--- a/src/SharpModMenu/PlayerMenuState.cs
+++ b/src/SharpModMenu/PlayerMenuState.cs
@@ -45,6 +45,9 @@ internal class PlayerMenuState : IDisposable
 	public bool WasPressingReload { get; set; }
 	public bool WasPressingTab { get; set; }
 
+	public int ClientTick { get; set; }
+	public int? InhibitWeaponSelection { get; set; }
+
 	public void HandleInput(PlayerKey key, bool fromBind)
 	{
 		if (key is >= PlayerKey.SelectItem1 and <= PlayerKey.SelectItem0 && fromBind)
@@ -52,6 +55,9 @@ internal class PlayerMenuState : IDisposable
 
 		if (CurrentMenu is null)
 			return;
+
+		if (key is >= PlayerKey.SelectItem1 and <= PlayerKey.SelectItem0 && fromBind)
+			InhibitWeaponSelection = ClientTick + 1;
 
 		var itemsStart = CurrentMenu.CurrentPage * Menu.ItemsPerPage;
 		var buttonState = CurrentMenu.GetButtonStates();


### PR DESCRIPTION
Console commands are processed before user commands, meaning even when bound as `slot1; css_1`, the `css_1` command is processed first, allowing us to inhibit a future slot change, further mirroring SourceMod menus

Also renamed various events to more correct names