### PR TITLE
Fix invisible players

### DIFF
--- a/src/SharpModMenu/SharpModMenu.cs
+++ b/src/SharpModMenu/SharpModMenu.cs
@@ -78,7 +78,7 @@ public sealed class SharpModMenuPlugin : BasePlugin
 				var info = infoList[n];
 				var entInfo = DriverInstance.MenuEntities[i];
 				if (entInfo.target != info.player && entInfo.target.IsValid)
-					info.info.TransmitEntities.Remove(entInfo.target);
+					info.info.TransmitEntities.Remove(entInfo.ent);
 			}
 		}
 	}


### PR DESCRIPTION
Instead of not sending the menu entities, the player to which they belong wasn't been sent instead, resulting in players with menus open not being transmitted.